### PR TITLE
Fix base docker image

### DIFF
--- a/setup/docker/dockerfiles/vitis-ai-gpu.Dockerfile
+++ b/setup/docker/dockerfiles/vitis-ai-gpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04
+FROM nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04
 env DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]
 ENV TZ=America/Denver


### PR DESCRIPTION
Now ` nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04` does not exist in Dockerhub.
```
Sending build context to Docker daemon   76.8kB
Step 1/61 : FROM nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04
manifest for nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04 not found: manifest unknown: manifest unknown
```
current available one is `nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04`.
